### PR TITLE
Add script to seed PostgreSQL with mock match data

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,7 @@ pip install -r requirements.txt
 # 5. Run your FastAPI server
 
 uvicorn LoginPage:app --reload
+
+# 6. (Optional) Seed the database with mock data
+
+python seed_db.py

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+
+class Match(Base):
+    __tablename__ = "matches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    league = Column(String, nullable=False)
+    home_team = Column(String, nullable=False)
+    away_team = Column(String, nullable=False)
+    home_score = Column(Integer, nullable=False)
+    away_score = Column(Integer, nullable=False)
+    kickoff_time = Column(DateTime, nullable=False)
+    status = Column(String, nullable=False)
+
+    events = relationship("MatchEvent", back_populates="match", cascade="all, delete-orphan")
+
+
+class MatchEvent(Base):
+    __tablename__ = "match_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    match_id = Column(Integer, ForeignKey("matches.id"), nullable=False)
+    minute = Column(Integer, nullable=False)
+    team = Column(String, nullable=False)
+    player = Column(String, nullable=False)
+    type = Column(String, nullable=False)
+
+    match = relationship("Match", back_populates="events")

--- a/backend/seed_db.py
+++ b/backend/seed_db.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from database import SessionLocal, create_tables, drop_tables
+from models import Match, MatchEvent
+
+
+def seed():
+    """Reset the database and insert mock match data."""
+    drop_tables()
+    create_tables()
+
+    db = SessionLocal()
+    try:
+        match1 = Match(
+            league="Premier League",
+            home_team="Arsenal",
+            away_team="Chelsea",
+            home_score=2,
+            away_score=1,
+            kickoff_time=datetime(2024, 10, 26, 15, 0),
+            status="live",
+            events=[
+                MatchEvent(minute=23, team="Arsenal", player="Saka", type="goal"),
+                MatchEvent(minute=45, team="Chelsea", player="Sterling", type="goal"),
+                MatchEvent(minute=70, team="Arsenal", player="Martinelli", type="goal"),
+            ],
+        )
+        match2 = Match(
+            league="La Liga",
+            home_team="Barcelona",
+            away_team="Real Madrid",
+            home_score=0,
+            away_score=0,
+            kickoff_time=datetime(2024, 10, 27, 18, 0),
+            status="scheduled",
+            events=[],
+        )
+
+        db.add_all([match1, match2])
+        db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()
+    print("Database seeded with mock data.")


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for matches and match events
- introduce seed_db script to populate PostgreSQL with sample data
- document optional database seeding step in backend README

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm test` in `vuetify-project` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892e266cfd08326852d32d42dfd1a9c