### PR TITLE
Use database for match API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,14 @@
 from datetime import datetime
 from typing import List
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from sqlalchemy.orm import Session, selectinload
+
+from database import get_db
+from models import Match as DBMatch
+
 
 app = FastAPI()
 
@@ -22,6 +27,9 @@ class MatchEvent(BaseModel):
     player: str
     type: str
 
+    class Config:
+        orm_mode = True
+
 
 class Match(BaseModel):
     id: int
@@ -34,47 +42,26 @@ class Match(BaseModel):
     status: str
     events: List[MatchEvent] = []
 
-
-MOCK_MATCHES: List[Match] = [
-    Match(
-        id=1,
-        league="Premier League",
-        home_team="Arsenal",
-        away_team="Chelsea",
-        home_score=2,
-        away_score=1,
-        kickoff_time=datetime(2024, 10, 26, 15, 0),
-        status="live",
-        events=[
-            MatchEvent(minute=23, team="Arsenal", player="Saka", type="goal"),
-            MatchEvent(minute=45, team="Chelsea", player="Sterling", type="goal"),
-            MatchEvent(minute=70, team="Arsenal", player="Martinelli", type="goal"),
-        ],
-    ),
-    Match(
-        id=2,
-        league="La Liga",
-        home_team="Barcelona",
-        away_team="Real Madrid",
-        home_score=0,
-        away_score=0,
-        kickoff_time=datetime(2024, 10, 27, 18, 0),
-        status="scheduled",
-        events=[],
-    ),
-]
+    class Config:
+        orm_mode = True
 
 
 @app.get("/api/matches", response_model=List[Match])
-def list_matches() -> List[Match]:
+def list_matches(db: Session = Depends(get_db)) -> List[DBMatch]:
     """Return all available matches."""
-    return MOCK_MATCHES
+    return db.query(DBMatch).options(selectinload(DBMatch.events)).all()
 
 
 @app.get("/api/matches/{match_id}", response_model=Match)
-def get_match(match_id: int) -> Match:
+def get_match(match_id: int, db: Session = Depends(get_db)) -> DBMatch:
     """Return a single match by its identifier."""
-    for match in MOCK_MATCHES:
-        if match.id == match_id:
-            return match
-    raise HTTPException(status_code=404, detail="Match not found")
+    match = (
+        db.query(DBMatch)
+        .options(selectinload(DBMatch.events))
+        .filter(DBMatch.id == match_id)
+        .first()
+    )
+    if not match:
+        raise HTTPException(status_code=404, detail="Match not found")
+    return match
+


### PR DESCRIPTION
## Summary
- remove hard-coded match list
- load matches and events from PostgreSQL database via SQLAlchemy

## Testing
- `pytest`
- `python backend/seed_db.py` *(fails: connection refused)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892eb6c724483269afb38311f318513