### PR TITLE
Add league table and team stats pages with shared font utilities

### DIFF
--- a/vuetify-project/src/main.ts
+++ b/vuetify-project/src/main.ts
@@ -4,20 +4,22 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Composables
+import { createApp } from 'vue'
+
 // Plugins
 import { registerPlugins } from '@/plugins'
 
 // Components
 import App from './App.vue'
 
-// Composables
-import { createApp } from 'vue'
-
 // Styles
 import 'unfonts.css'
+import '@/styles/override-font.css'
 
 const app = createApp(App)
 
 registerPlugins(app)
 
 app.mount('#app')
+

--- a/vuetify-project/src/pages/index.vue
+++ b/vuetify-project/src/pages/index.vue
@@ -8,26 +8,26 @@
     </v-row>
 
     <!-- Filters Row -->
-    <v-row class="mb-4" align="center">
+    <v-row align="center" class="mb-4">
       <v-spacer />
 
       <!-- League filter -->
       <v-col cols="auto" style="min-width:200px">
         <v-select
           v-model="league"
-          :items="leagues"
           clearable
+          :items="leagues"
           label="Filter by league"
           style="max-width:250px"
         />
       </v-col>
-    <v-col cols="auto" style="min-width:200px">
-      <DateFilter v-model="after" label="Kickoff After" />
+      <v-col cols="auto" style="min-width:200px">
+        <DateFilter v-model="after" label="Kickoff After" />
 
-    </v-col>
-    <v-col cols="auto" style="min-width:200px">
-      <DateFilter v-model="before" label="Kickoff Before" />
-    </v-col>
+      </v-col>
+      <v-col cols="auto" style="min-width:200px">
+        <DateFilter v-model="before" label="Kickoff Before" />
+      </v-col>
 
     </v-row>
 
@@ -50,7 +50,7 @@
             <div class="text-h5">
               {{ match.home_score }} - {{ match.away_score }}
             </div>
-            <v-list v-if="match.events.length">
+            <v-list v-if="match.events.length > 0">
               <v-list-item
                 v-for="(evt, idx) in match.events"
                 :key="idx"
@@ -68,49 +68,55 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import DateFilter from '@/components/DateFilter.vue'
+  import { computed, onMounted, ref } from 'vue'
+  import DateFilter from '@/components/DateFilter.vue'
 
-interface MatchEvent { minute: number; team: string; player: string; type: string }
-interface Match {
-  id: number
-  league: string
-  home_team: string
-  away_team: string
-  home_score: number
-  away_score: number
-  kickoff_time: string
-  status: string
-  events: MatchEvent[]
-}
+  interface MatchEvent {
+    minute: number
+    team: string
+    player: string
+    type: string
+  }
+  interface Match {
+    id: number
+    league: string
+    home_team: string
+    away_team: string
+    home_score: number
+    away_score: number
+    kickoff_time: string
+    status: string
+    events: MatchEvent[]
+  }
 
-const matches = ref<Match[]>([])
-const league  = ref<string|null>(null)
-const after   = ref<string|null>(null)
-const before  = ref<string|null>(null)
+  const matches = ref<Match[]>([])
+  const league = ref<string | null>(null)
+  const after = ref<string | null>(null)
+  const before = ref<string | null>(null)
 
-const leagues = computed(() =>
-  Array.from(new Set(matches.value.map(m => m.league)))
-)
+  const leagues = computed(() =>
+    Array.from(new Set(matches.value.map(m => m.league))),
+  )
 
-const filteredMatches = computed(() =>
-  matches.value.filter(m => {
-    const t = new Date(m.kickoff_time).getTime()
+  const filteredMatches = computed(() =>
+    matches.value.filter(m => {
+      const t = new Date(m.kickoff_time).getTime()
 
-    const leagueOk = league.value ? m.league === league.value : true
-    const afterOk  = after.value  ? t >= new Date(after.value).getTime()   : true
-    const beforeOk = before.value ? t <= new Date(before.value).getTime()  : true
+      const leagueOk = league.value ? m.league === league.value : true
+      const afterOk = after.value ? t >= new Date(after.value).getTime() : true
+      const beforeOk = before.value ? t <= new Date(before.value).getTime() : true
 
-    return leagueOk && afterOk && beforeOk
+      return leagueOk && afterOk && beforeOk
+    }),
+  )
+
+  onMounted(async () => {
+    const res = await fetch('http://localhost:8000/api/matches')
+    matches.value = await res.json()
   })
-)
 
-onMounted(async () => {
-  const res = await fetch('http://localhost:8000/api/matches')
-  matches.value = await res.json()
-})
-
-function formatKickoff(iso: string) {
-  return new Date(iso).toLocaleString()
-}
+  function formatKickoff (iso: string) {
+    return new Date(iso).toLocaleString()
+  }
 </script>
+

--- a/vuetify-project/src/pages/league-table.vue
+++ b/vuetify-project/src/pages/league-table.vue
@@ -1,0 +1,118 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1 class="font-bold">League Table</h1>
+        <v-table class="mt-4">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Team</th>
+              <th>P</th>
+              <th>W</th>
+              <th>D</th>
+              <th>L</th>
+              <th>GF</th>
+              <th>GA</th>
+              <th>GD</th>
+              <th>Pts</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(team, i) in table" :key="team.name">
+              <td>{{ i + 1 }}</td>
+              <td>{{ team.name }}</td>
+              <td>{{ team.played }}</td>
+              <td>{{ team.wins }}</td>
+              <td>{{ team.draws }}</td>
+              <td>{{ team.losses }}</td>
+              <td>{{ team.gf }}</td>
+              <td>{{ team.ga }}</td>
+              <td>{{ team.gf - team.ga }}</td>
+              <td>{{ team.points }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue'
+
+  interface Match {
+    id: number
+    league: string
+    home_team: string
+    away_team: string
+    home_score: number
+    away_score: number
+    kickoff_time: string
+    status: string
+  }
+
+  interface TeamRow {
+    name: string
+    played: number
+    wins: number
+    draws: number
+    losses: number
+    gf: number
+    ga: number
+    points: number
+  }
+
+  const matches = ref<Match[]>([])
+
+  onMounted(async () => {
+    const res = await fetch('http://localhost:8000/api/matches')
+    matches.value = await res.json()
+  })
+
+  const table = computed<TeamRow[]>(() => {
+    const map = new Map<string, TeamRow>()
+
+    for (const m of matches.value) {
+      const home = map.get(m.home_team) || { name: m.home_team, played: 0, wins: 0, draws: 0, losses: 0, gf: 0, ga: 0, points: 0 }
+      const away = map.get(m.away_team) || { name: m.away_team, played: 0, wins: 0, draws: 0, losses: 0, gf: 0, ga: 0, points: 0 }
+
+      home.played++
+      away.played++
+      home.gf += m.home_score
+      home.ga += m.away_score
+      away.gf += m.away_score
+      away.ga += m.home_score
+
+      if (m.home_score > m.away_score) {
+        home.wins++
+        home.points += 3
+        away.losses++
+      } else if (m.home_score < m.away_score) {
+        away.wins++
+        away.points += 3
+        home.losses++
+      } else {
+        home.draws++
+        away.draws++
+        home.points++
+        away.points++
+      }
+
+      map.set(home.name, home)
+      map.set(away.name, away)
+    }
+
+    return Array.from(map.values()).sort((a, b) => {
+      if (b.points !== a.points) return b.points - a.points
+      const gdA = a.gf - a.ga
+      const gdB = b.gf - b.ga
+      if (gdB !== gdA) return gdB - gdA
+      return b.gf - a.gf
+    })
+  })
+</script>
+
+<style scoped>
+</style>
+

--- a/vuetify-project/src/pages/team-stats.vue
+++ b/vuetify-project/src/pages/team-stats.vue
@@ -1,0 +1,139 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h1 class="font-bold">Team Stats</h1>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12" sm="4">
+        <v-select
+          v-model="team"
+          clearable
+          :items="teams"
+          label="Select Team"
+        />
+      </v-col>
+    </v-row>
+
+    <v-row v-if="stats">
+      <v-col cols="12" md="6">
+        <v-table>
+          <tbody>
+            <tr>
+              <th class="text-left">Played</th>
+              <td>{{ stats.played }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Wins</th>
+              <td>{{ stats.wins }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Draws</th>
+              <td>{{ stats.draws }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Losses</th>
+              <td>{{ stats.losses }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Goals For</th>
+              <td>{{ stats.gf }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Goals Against</th>
+              <td>{{ stats.ga }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Goal Difference</th>
+              <td>{{ stats.gf - stats.ga }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">Points</th>
+              <td>{{ stats.points }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue'
+
+  interface Match {
+    id: number
+    league: string
+    home_team: string
+    away_team: string
+    home_score: number
+    away_score: number
+    kickoff_time: string
+    status: string
+  }
+
+  interface TeamStats {
+    played: number
+    wins: number
+    draws: number
+    losses: number
+    gf: number
+    ga: number
+    points: number
+  }
+
+  const matches = ref<Match[]>([])
+  const team = ref<string | null>(null)
+
+  onMounted(async () => {
+    const res = await fetch('http://localhost:8000/api/matches')
+    matches.value = await res.json()
+  })
+
+  const teams = computed(() =>
+    Array.from(new Set(matches.value.flatMap(m => [m.home_team, m.away_team]))).sort(),
+  )
+
+  const stats = computed<TeamStats | null>(() => {
+    if (!team.value) return null
+    const s: TeamStats = {
+      played: 0,
+      wins: 0,
+      draws: 0,
+      losses: 0,
+      gf: 0,
+      ga: 0,
+      points: 0,
+    }
+
+    for (const m of matches.value) {
+      let isHome: boolean | null = null
+      if (m.home_team === team.value) isHome = true
+      else if (m.away_team === team.value) isHome = false
+      else continue
+
+      s.played++
+      const gf = isHome ? m.home_score : m.away_score
+      const ga = isHome ? m.away_score : m.home_score
+      s.gf += gf
+      s.ga += ga
+
+      if (gf > ga) {
+        s.wins++
+        s.points += 3
+      } else if (gf < ga) {
+        s.losses++
+      } else {
+        s.draws++
+        s.points++
+      }
+    }
+
+    return s
+  })
+</script>
+
+<style scoped>
+</style>
+

--- a/vuetify-project/src/styles/override-font.css
+++ b/vuetify-project/src/styles/override-font.css
@@ -1,0 +1,26 @@
+/* Global font utility classes for cross-page compatibility */
+
+.font-sm {
+  font-size: 0.875rem;
+}
+
+.font-md {
+  font-size: 1rem;
+}
+
+.font-lg {
+  font-size: 1.25rem;
+}
+
+.font-light {
+  font-weight: 300;
+}
+
+.font-regular {
+  font-weight: 400;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+


### PR DESCRIPTION
## Summary
- add league table page computing standings from match data
- add team stats view for per-team performance
- standardize typography via shared `override-font.css` and global import

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689313f645808326a4e10212b2a95da9