### PR TITLE
Add fake live data pipeline and match polling store

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,17 @@
 from datetime import datetime
+import asyncio
+import random
 from typing import List
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from sqlalchemy.orm import Session, selectinload
 
-from database import get_db
-from models import Match as DBMatch
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from database import get_db, SessionLocal
+from models import Match as DBMatch, MatchEvent as DBMatchEvent
 
 FrontendTestMode: bool = False  # Set to True for testing with mock data
 app = FastAPI()
@@ -41,6 +45,7 @@ class Match(BaseModel):
     kickoff_time: datetime
     status: str
     events: List[MatchEvent] = []
+    current_minute: int | None = None
 
     class Config:
         orm_mode = True
@@ -74,12 +79,32 @@ MOCK_MATCHES: List[Match] = [
     ),
 ]
 
+def compute_current_minute(match: DBMatch) -> int | None:
+    """Return the current minute for a live match."""
+    if match.status != "live":
+        return None
+    diff = datetime.utcnow() - match.kickoff_time
+    minute = int(diff.total_seconds() // 60)
+    return max(0, min(90, minute))
+
+
+def to_schema(db_match: DBMatch) -> Match:
+    match = Match.from_orm(db_match)
+    match.current_minute = compute_current_minute(db_match)
+    return match
+
+
+def get_matches(db: Session) -> List[Match]:
+    db_matches = db.query(DBMatch).options(selectinload(DBMatch.events)).all()
+    return [to_schema(m) for m in db_matches]
+
+
 @app.get("/api/matches", response_model=List[Match])
 def list_matches(db: Session = Depends(get_db)) -> List[Match]:
     """Return all available matches."""
     if FrontendTestMode:
         return MOCK_MATCHES
-    return db.query(DBMatch).options(selectinload(DBMatch.events)).all()
+    return get_matches(db)
 
 
 @app.get("/api/matches/{match_id}", response_model=Match)
@@ -98,5 +123,78 @@ def get_match(match_id: int, db: Session = Depends(get_db)) -> Match:
     )
     if not match:
         raise HTTPException(status_code=404, detail="Match not found")
-    return match
+    return to_schema(match)
+
+
+def simulate_events() -> None:
+    """Randomly insert events for live matches."""
+    db = SessionLocal()
+    try:
+        live_matches = db.query(DBMatch).filter(DBMatch.status == "live").all()
+        for match in live_matches:
+            current_minute = compute_current_minute(match)
+            if current_minute is None or current_minute >= 90:
+                continue
+            if random.random() >= 0.3:
+                continue
+            event_type = random.choice(["goal", "yellow_card", "substitution"])
+            team_choice = random.choice(["home", "away"])
+            team_name = match.home_team if team_choice == "home" else match.away_team
+            player_out = f"Player {random.randint(1,99)}"
+            if event_type == "goal":
+                if team_choice == "home":
+                    match.home_score += 1
+                else:
+                    match.away_score += 1
+                event = DBMatchEvent(
+                    match_id=match.id,
+                    minute=current_minute,
+                    team=team_name,
+                    player=player_out,
+                    type="goal",
+                )
+            elif event_type == "yellow_card":
+                event = DBMatchEvent(
+                    match_id=match.id,
+                    minute=current_minute,
+                    team=team_name,
+                    player=player_out,
+                    type="yellow_card",
+                )
+            else:  # substitution
+                player_in = f"Player {random.randint(100,199)}"
+                event = DBMatchEvent(
+                    match_id=match.id,
+                    minute=current_minute,
+                    team=team_name,
+                    player=player_out,
+                    type="substitution",
+                    sub_in=player_in,
+                )
+            db.add(event)
+        db.commit()
+    finally:
+        db.close()
+
+
+scheduler = BackgroundScheduler()
+scheduler.add_job(simulate_events, "interval", seconds=10)
+
+
+@app.on_event("startup")
+def start_scheduler() -> None:
+    scheduler.start()
+
+
+@app.websocket("/ws/matches")
+async def ws_matches(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        while True:
+            with SessionLocal() as db:
+                matches = get_matches(db)
+            await websocket.send_json([m.dict() for m in matches])
+            await asyncio.sleep(5)
+    except WebSocketDisconnect:
+        pass
 

--- a/vuetify-project/package.json
+++ b/vuetify-project/package.json
@@ -16,7 +16,8 @@
     "@mdi/font": "7.4.47",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",
-    "vuetify": "^3.9.1"
+    "vuetify": "^3.9.1",
+    "axios": "^1.7.7"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",

--- a/vuetify-project/src/pages/index.vue
+++ b/vuetify-project/src/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Hero / Landing intro (full-width) -->
-  <v-sheet class="d-flex flex-column justify-center hero pt-2 pb-10" height="160" elevation="0">
+  <v-sheet class="d-flex flex-column justify-center hero pt-2 pb-10" elevation="0" height="160">
     <div class="w-100 text-center">
       <h1 class="display-2 font-weight-bold mb-2">
         Football Match Tracker
@@ -21,8 +21,14 @@
 
         <v-row justify="end">
           <v-spacer />
-          <v-select v-model="league" :items="leagues" clearable label="Filter by league" style="max-width:250px"
-            class="ma-3" />
+          <v-select
+            v-model="league"
+            class="ma-3"
+            clearable
+            :items="leagues"
+            label="Filter by league"
+            style="max-width:250px"
+          />
           <v-col cols="auto" style="min-width:300px">
             <DateFilter v-model="before" label="Kickoff Before" />
           </v-col>
@@ -52,7 +58,7 @@
                 <v-card class="match-card">
                   <v-card-title class="d-flex justify-space-between align-center">
                     <span>{{ match.home_team }} vs {{ match.away_team }}</span>
-                    <v-btn icon flat @click="toggle(match.id)">
+                    <v-btn flat icon @click="toggle(match.id)">
                       <v-icon>{{ isExpanded(match.id) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}</v-icon>
                     </v-btn>
                   </v-card-title>
@@ -65,18 +71,22 @@
                     </div>
                   </v-card-text>
                   <v-expand-transition>
-                    
-                    <v-sheet v-show="isExpanded(match.id)" elevation="0" class="pa-0" color="transparent">
+
+                    <v-sheet v-show="isExpanded(match.id)" class="pa-0" color="transparent" elevation="0">
                       <v-divider class="my-2" />
-                      <v-list v-if="goalEvents(match).length">
-                        <v-list-item v-for="(evt, i) in goalEvents(match)" :key="i">
+                      <v-list v-if="highlightEvents(match).length > 0">
+                        <v-list-item v-for="(evt, i) in highlightEvents(match)" :key="i">
                           <v-list-item-title>
-                            {{ evt.minute }}' {{ evt.player }} ({{ evt.team }})
+                            {{ evt.minute }}' {{ evt.player }}
+                            <template v-if="evt.type === 'substitution'">
+                              → {{ evt.sub_in }}
+                            </template>
+                            ({{ evt.team }}) - {{ evt.type }}
                           </v-list-item-title>
                         </v-list-item>
                       </v-list>
 
-                      <v-btn class="detail-button ma-4"  @click="goToMatch(match.id)">
+                      <v-btn class="detail-button ma-4" @click="goToMatch(match.id)">
                         More Details
                       </v-btn>
                     </v-sheet>
@@ -93,81 +103,64 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import DateFilter from '@/components/DateFilter.vue'
+  import { storeToRefs } from 'pinia'
+  import { computed, onMounted, ref } from 'vue'
+  import { useRouter } from 'vue-router'
+  import DateFilter from '@/components/DateFilter.vue'
+  import { type Match, useMatches } from '@/stores/matches'
 
-interface MatchEvent {
-  minute: number
-  team: string
-  player: string
-  type: string
-}
-interface Match {
-  id: number
-  league: string
-  home_team: string
-  away_team: string
-  home_score: number
-  away_score: number
-  kickoff_time: string
-  status: string
-  events: MatchEvent[]
-}
+  const matchesStore = useMatches()
+  const { matches } = storeToRefs(matchesStore)
+  const expanded = ref<Set<number>>(new Set())
+  const league = ref<string | null>(null)
+  const after = ref<string | null>(null)
+  const before = ref<string | null>(null)
+  const router = useRouter()
 
-const matches = ref<Match[]>([])
-const expanded = ref<Set<number>>(new Set())
-const league = ref<string | null>(null)
-const after = ref<string | null>(null)
-const before = ref<string | null>(null)
-const router = useRouter()
+  const leagues = computed(() =>
+    Array.from(new Set(matches.value.map(m => m.league))),
+  )
 
-const leagues = computed(() =>
-  Array.from(new Set(matches.value.map(m => m.league)))
-)
+  const filtered = computed(() =>
+    matches.value.filter(m => {
+      const t = new Date(m.kickoff_time).getTime()
+      return (
+        (!league.value || m.league === league.value)
+        && (!after.value || t >= new Date(after.value).getTime())
+        && (!before.value || t <= new Date(before.value).getTime())
+      )
+    }),
+  )
 
-const filtered = computed(() =>
-  matches.value.filter(m => {
-    const t = new Date(m.kickoff_time).getTime()
-    return (
-      (!league.value || m.league === league.value) &&
-      (!after.value || t >= new Date(after.value).getTime()) &&
-      (!before.value || t <= new Date(before.value).getTime())
-    )
+  // 3) split into status groups
+  const filteredByStatus = computed(() => {
+    const groups: Record<string, Match[]> = {
+      live: [], scheduled: [], finished: [],
+    }
+    for (const m of filtered.value) {
+      if (groups[m.status]) groups[m.status].push(m)
+      else groups.scheduled.push(m)
+    }
+    return groups
   })
-)
 
-// 3) split into status groups
-const filteredByStatus = computed(() => {
-  const groups: Record<string, Match[]> = {
-    live: [], scheduled: [], finished: []
+  onMounted(() => {
+    matchesStore.connectWS()
+  })
+  function highlightEvents (m: Match) {
+    return m.events.filter(e => ['goal', 'yellow_card', 'substitution'].includes(e.type))
   }
-  filtered.value.forEach(m => {
-    if (groups[m.status]) groups[m.status].push(m)
-    else groups.scheduled.push(m)
-  })
-  return groups
-})
-
-onMounted(async () => {
-  const res = await fetch('http://localhost:8000/api/matches')
-  matches.value = await res.json()
-})
-
-function goalEvents(m: Match) {
-  return m.events.filter(e => e.type === 'goal')
-}
-function toggle(id: number) {
-  expanded.value.has(id)
-    ? expanded.value.delete(id)
-    : expanded.value.add(id)
-}
-function isExpanded(id: number) {
-  return expanded.value.has(id)
-}
-function goToMatch(id: number) {
-  router.push(`/match/${id}`)
-}
+  function toggle (id: number) {
+    expanded.value.has(id)
+      ? expanded.value.delete(id)
+      : expanded.value.add(id)
+  }
+  function isExpanded (id: number) {
+    return expanded.value.has(id)
+  }
+  function goToMatch (id: number) {
+    router.push(`/match/${id}`)
+  }
 </script>
 
 <style scoped></style>

--- a/vuetify-project/src/stores/matches.ts
+++ b/vuetify-project/src/stores/matches.ts
@@ -1,0 +1,55 @@
+import axios from 'axios'
+import { defineStore } from 'pinia'
+
+export interface MatchEvent {
+  minute: number
+  team: string
+  player: string
+  type: string
+  sub_in?: string | null
+}
+
+export interface Match {
+  id: number
+  league: string
+  home_team: string
+  away_team: string
+  home_score: number
+  away_score: number
+  kickoff_time: string
+  status: string
+  events: MatchEvent[]
+  current_minute?: number | null
+}
+
+let poll: number | null = null
+let ws: WebSocket | null = null
+
+export const useMatches = defineStore('matches', {
+  state: () => ({
+    matches: [] as Match[],
+  }),
+  actions: {
+    async fetchAll () {
+      const { data } = await axios.get('/api/matches')
+      this.matches = data
+    },
+    startPolling () {
+      this.fetchAll()
+      if (poll) {
+        clearInterval(poll)
+      }
+      poll = setInterval(() => this.fetchAll(), 10_000)
+    },
+    connectWS () {
+      if (ws) {
+        ws.close()
+      }
+      const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
+      ws = new WebSocket(`${protocol}://${window.location.host}/ws/matches`)
+      ws.addEventListener('message', e => {
+        this.matches = JSON.parse(e.data)
+      })
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- simulate live match events with APScheduler and expose `/ws/matches` stream
- add Pinia matches store with axios fetching, polling and websocket updates
- update match list page to consume store and show live events

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/database.py`
- `npm install axios` *(fails: 403 Forbidden to registry)*
- `npm run lint` *(fails: league-table.vue style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68945bba52bc8326ade1c5edccc8aec4